### PR TITLE
-s factomd location honored in compose

### DIFF
--- a/addchain.go
+++ b/addchain.go
@@ -160,6 +160,7 @@ var composechain = func() *fctCmd {
 		)
 		os.Args = args
 		exidCollector = make([][]byte, 0)
+
 		flag.Var(&eAcii, "n", "Chain name element in ascii. Also is extid of"+
 			" First Entry")
 		flag.Var(&eHex, "h", "Chain name element in hex. Also is extid of"+
@@ -202,15 +203,17 @@ var composechain = func() *fctCmd {
 			return
 		}
 
+		factomdServer := GetFactomdServer()
+
 		fmt.Println(
 			"curl -X POST --data-binary",
 			"'"+commit.String()+"'",
-			"-H 'content-type:text/plain;' http://localhost:8088/v2",
+			"-H 'content-type:text/plain;' http://"+factomdServer+"/v2",
 		)
 		fmt.Println(
 			"curl -X POST --data-binary",
 			"'"+reveal.String()+"'",
-			"-H 'content-type:text/plain;' http://localhost:8088/v2",
+			"-H 'content-type:text/plain;' http://"+factomdServer+"/v2",
 		)
 
 	}

--- a/addentry.go
+++ b/addentry.go
@@ -245,15 +245,17 @@ var composeentry = func() *fctCmd {
 			return
 		}
 
+		factomdServer := GetFactomdServer()
+
 		fmt.Println(
 			"curl -X POST --data-binary",
 			"'"+commit.String()+"'",
-			"-H 'content-type:text/plain;' http://localhost:8088/v2",
+			"-H 'content-type:text/plain;' http://"+factomdServer+"/v2",
 		)
 		fmt.Println(
 			"curl -X POST --data-binary",
 			"'"+reveal.String()+"'",
-			"-H 'content-type:text/plain;' http://localhost:8088/v2",
+			"-H 'content-type:text/plain;' http://"+factomdServer+"/v2",
 		)
 	}
 	help.Add("composeentry", cmd)

--- a/transaction.go
+++ b/transaction.go
@@ -588,10 +588,13 @@ var composetx = func() *fctCmd {
 			errorln(err)
 			return
 		}
+
+		factomdServer := GetFactomdServer()
+
 		fmt.Println(
 			"curl -X POST --data-binary",
 			"'"+string(p)+"'",
-			"-H 'content-type:text/plain;' http://localhost:8088/v2",
+			"-H 'content-type:text/plain;' http://"+factomdServer+"/v2",
 		)
 	}
 	help.Add("composetx", cmd)

--- a/util.go
+++ b/util.go
@@ -15,6 +15,16 @@ import (
 	"github.com/FactomProject/factom"
 )
 
+// GetFactomdServer returns the current factomd server set in the factom package.
+// This is used for compose functions to put the appropriate url in the sample curl
+//		localhost:8088 is returned if the factom package does not have one set
+func GetFactomdServer() string {
+	if factom.RpcConfig != nil && factom.RpcConfig.FactomdServer != "" {
+		return factom.RpcConfig.FactomdServer
+	}
+	return "localhost:8088"
+}
+
 // exidCollector accumulates the external ids from the command line -e and -E
 // flags
 var exidCollector [][]byte


### PR DESCRIPTION
Compose commands now print the curl calls with the same factomd
location given by the -s command if provided